### PR TITLE
script used to complete internetarchive/openlibrary/issues/1046

### DIFF
--- a/tasks/clear-fakes.py
+++ b/tasks/clear-fakes.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+from copy import copy
+import sys
+from olclient.openlibrary import OpenLibrary
+
+"""
+   Removes 'fake' ex-system subjects from Open Library works or editions.
+   Takes as CLI argument a filename containing a list of Open Library keys:
+   e.g.
+     /works/OL1001319W
+     /books/OL24710466M
+"""
+
+ol = OpenLibrary()
+
+inlist = sys.argv[1]
+
+fakes = ['overdrive', 'in library', 'accessible book', 'protected daisy', 'lending library', 'internet archive wishlist']
+# only remove these from works:
+wfakes = ['large type books', 'popular print disabled books']
+
+
+otherbad = ['fictiion']
+
+fakes += otherbad
+changes_made = 0
+with open(inlist, 'r') as f:
+    for item in f:
+        olid = item.strip().replace('/books/', '').replace('/works/', '')
+        book = ol.get(olid)
+        if not book.type.get('key') in ('/type/edition', '/type/work'):
+            print("Unexpected type for %s -- Skipping!" % olid)
+        else:
+            orig_subjects = []
+            if hasattr(book, 'subjects'):
+                orig_subjects = copy(book.subjects)
+            else:
+                continue
+            #print(olid)
+            #print(u"%s: %s -- %s" % (olid, book.title, orig_subjects))
+            targets = copy(fakes)
+            if book.type['key'] == '/type/work':
+                targets += wfakes
+            removals = []
+            for s in book.subjects:
+                if s.lower() in targets:
+                    #print("%s -- Fake subject %s found!" % (olid, s))
+                    removals.append(s)
+                if s.lower() != s: # remove duplicate lowercased subjects
+                    if s.lower() in book.subjects:
+                        #print("  Removing dupe lower(): %s" % s.lower())
+                        removals.append(s.lower())
+            for r in removals:
+                try:
+                    book.subjects.remove(r)
+                except ValueError:
+                    print(' unable to remove %s from %s -- probably already removed?' % (r, olid))
+            if book.subjects != orig_subjects:
+                #print("SUBJECTS CHANGED -- TO SAVE!")
+                #print("New subjects: %s" % book.subjects)
+                r = book.save('remove fake subjects')
+                if r.status_code != 200:  # Only log unsuccessful saves
+                    print('%s: %s' % (olid, r))
+                else:
+                    changes_made += 1
+print('%s subject changes saved.' % changes_made)

--- a/tasks/writeback-olids.py
+++ b/tasks/writeback-olids.py
@@ -1,4 +1,4 @@
-# iterate through archive.org items with onlt openlibrary
+# iterate through archive.org items with only openlibrary
 # and write back openlibrary_edition and openlibrary_work
 
 import json

--- a/tasks/writeback-olids.py
+++ b/tasks/writeback-olids.py
@@ -1,0 +1,40 @@
+# iterate through archive.org items with onlt openlibrary
+# and write back openlibrary_edition and openlibrary_work
+
+import json
+import sys
+import time
+import requests
+from internetarchive import modify_metadata
+from olclient.openlibrary import OpenLibrary
+
+fname = sys.argv[1]
+
+ol = OpenLibrary()
+
+n = 0
+with open(fname, 'r') as f:
+   for line in f.readlines():
+       data = json.loads(line)
+       olid = data['openlibrary']
+       ocaid = data['identifier']
+       try: 
+           e = ol.get(olid)
+           wolid = e.work.olid
+           assert wolid
+       except requests.exceptions.HTTPError as e:
+           print('404', olid, ocaid)
+           wolid = None
+       to_write = {
+           'openlibrary_edition': olid
+       }
+       if wolid:
+           to_write['openlibrary_work'] = wolid
+       #print(ocaid, to_write)
+       r = modify_metadata(ocaid, metadata=to_write)
+       print('%s: %s' % (ocaid, r.status_code))
+       n += 1
+       if n > 300:
+           print('PAUSE')
+           time.sleep(900)
+           n = 0 


### PR DESCRIPTION
Performs the last part of
https://github.com/internetarchive/openlibrary/issues/1046
, writing openlibrary_edition and openlibrary_work ids to archive.org
items having an openlibrary id that already has been synced with a
different (i.e. duplicate) archive.org item.
There were about 7000 of these.